### PR TITLE
fix issue #14 "bad component(expected absolute path component)"

### DIFF
--- a/lib/spidr/links.rb
+++ b/lib/spidr/links.rb
@@ -209,6 +209,11 @@ module Spidr
         return nil
       end
 
+      # do not handle FTP
+      if url.scheme == 'ftp'
+        return nil
+      end
+
       if new_url.path
         # make sure the path does not contain any .. or . directories,
         # since URI::Generic#merge cannot normalize paths such as


### PR DESCRIPTION
to_absolute should reject ftp links

```
if you want an absolute path from URI::FTP you must escape the leading /
see the docs at http://www.ruby-doc.org/stdlib/libdoc/uri/rdoc/classes/URI/FTP.html#M009431
```
