### PR TITLE
application/xml should be handled as xml

### DIFF
--- a/lib/spidr/headers.rb
+++ b/lib/spidr/headers.rb
@@ -142,7 +142,8 @@ module Spidr
     #   Specifies whether the page is XML document.
     #
     def xml?
-      is_content_type?('text/xml')
+      is_content_type?('text/xml') || \
+        is_content_type?('application/xml')
     end
 
     #


### PR DESCRIPTION
Page#xml? checks for text/xml but not application/xml.  It should check for either.
