### PR TITLE
Fix warning instance variable @robots not initialized

### DIFF
--- a/lib/spidr/spidr.rb
+++ b/lib/spidr/spidr.rb
@@ -16,6 +16,7 @@ module Spidr
   # @since 0.5.0
   #
   def self.robots?
+    @robots ||= false
     @robots
   end
 


### PR DESCRIPTION
~~~
.gem/ruby/2.3.0/gems/spidr-0.6.0/lib/spidr/spidr.rb:19: warning: instance variable @robots not initialized
~~~