### PR TITLE
Respect `<base href="...">` tags

### DIFF
--- a/lib/spidr/page/html.rb
+++ b/lib/spidr/page/html.rb
@@ -266,7 +266,7 @@ module Spidr
     def to_absolute(link)
       link    = link.to_s
       new_url = begin
-                  url.merge(link)
+                  base_uri.merge(link)
                 rescue Exception
                   return
                 end
@@ -284,6 +284,15 @@ module Spidr
       end
 
       return new_url
+    end
+
+    def base_uri
+      if (html? && doc)
+        base_tag = doc.search('//base[@href]').first
+        base_tag ? URI(base_tag.get_attribute('href')) : url
+      else
+        url
+      end
     end
   end
 end

--- a/spec/page/html_spec.rb
+++ b/spec/page/html_spec.rb
@@ -520,5 +520,17 @@ describe Page do
         end
       end
     end
+
+    context "when the page has a base tag" do
+      let(:base_href) { "http://www.google.com/" }
+      let(:body) { %{<html><head><base href="#{base_href}"><title>example</title></head><body><p>hello</p></body></html>} }
+      let(:link) { "/foo/" }
+
+      subject { super().to_absolute(link) }
+
+      it "should set the hostname to that of the base tag instead of the page's URL" do
+        expect(subject).to be == URI("#{base_href}").merge(link)
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently `<base href="...">` tags are not taken into account and will send the spider to the wrong URL on pages with a base tag. With this patch, the spider correctly calculates absolute URLs when a base tag is present.