### PR TITLE
fix: use the correct status code for timedout

### DIFF
--- a/lib/spidr/page/status_codes.rb
+++ b/lib/spidr/page/status_codes.rb
@@ -23,16 +23,6 @@ module Spidr
     alias ok? is_ok?
 
     #
-    # Determines if the response code is `308`.
-    #
-    # @return [Boolean]
-    #   Specifies whether the response code is `308`.
-    #
-    def timedout?
-      code == 308
-    end
-
-    #
     # Determines if the response code is `400`.
     #
     # @return [Boolean]
@@ -77,6 +67,18 @@ module Spidr
     end
 
     alias missing? is_missing?
+
+    #
+    # Determines if the response code is `408`.
+    #
+    # @return [Boolean]
+    #   Specifies whether the response code is `408`.
+    #
+    def is_timedout?
+      code == 408
+    end
+
+    alias timedout? is_timedout?
 
     #
     # Determines if the response code is `500`.

--- a/spec/page/status_codes_spec.rb
+++ b/spec/page/status_codes_spec.rb
@@ -26,10 +26,6 @@ describe Page do
     include_examples "status code method", :is_ok?, {200 => true, 500 => false}
   end
 
-  describe "#timedout?" do
-    include_examples "status code method", :timedout?, {308 => true, 200 => false}
-  end
-
   describe "#bad_request?" do
     include_examples "status code method", :bad_request?, {400 => true, 200 => false}
   end
@@ -44,6 +40,10 @@ describe Page do
 
   describe "#is_missing?" do
     include_examples "status code method", :is_missing?, {404 => true, 200 => false}
+  end
+
+  describe "#is_timedout?" do
+    include_examples "status code method", :is_timedout?, {408 => true, 200 => false}
   end
 
   describe "#had_internal_server_error?" do


### PR DESCRIPTION
The HTTP status code for timedout is `408` not `308`.  This PR:

- fixes the status code int used in `Page#timedout?`
- changes the name of the method to `is_timedout?` for consistency with other methods
- aliases the changed method to `timedout?` for consistency with other methods
- moves the method within the file so it's in the correct place with respect to the sequential ordering by status code (probs not necessary but I'm not a total monster)
- updates the rspec

I couldn't find any guidance on contributing, so if I've missed anything anywhere, LMK! 🎈 