### PR TITLE
Use correct domain for solnic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ end
 Spider a host:
 
 ```ruby
-Spidr.host('solnic.eu') do |agent|
+Spidr.host('solnic.dev') do |agent|
   # ...
 end
 ```


### PR DESCRIPTION
Presumably, the domain changed at some point. The .eu domain is
definitely not what I expected!
